### PR TITLE
Fix passing in integer for endpoint choices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   global:
     - COLLECTION_NAMESPACE: fragmentedpacket
     - COLLECTION_NAME: netbox_modules
-    - COLLECTION_VERSION: 0.1.1
+    - COLLECTION_VERSION: 0.1.2
 
 matrix:
   include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,14 @@
 ## v0.1.2
 
 ### Bug Fixes
-- [#47] - Allow endpoint choices to be an integer of the choice rather than attempting to dynamically determine the choice ID
+- [#47](https://github.com/FragmentedPacket/netbox_modules/issues/47) - Allow endpoint choices to be an integer of the choice rather than attempting to dynamically determine the choice ID
 
 ## v0.1.1
 
 ### Bug Fixes
 
-- [#40](https://docs.ansible.com/ansible/latest/user_guide/collections_using.html#id7) - Fixed issue with netbox_vm_interface where it would fail if different virtual machine had the same interface name
-- [#40](https://docs.ansible.com/ansible/latest/user_guide/collections_using.html#id7) - Updated netbox_ip_address to find interfaces on virtual machines correctly
+- [#40](https://github.com/FragmentedPacket/netbox_modules/issues/40) - Fixed issue with netbox_vm_interface where it would fail if different virtual machine had the same interface name
+- [#40](https://github.com/FragmentedPacket/netbox_modules/issues/40) - Updated netbox_ip_address to find interfaces on virtual machines correctly
 
 ## v0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.1.2
+
+### Bug Fixes
+- [#47] - Allow endpoint choices to be an integer of the choice rather than attempting to dynamically determine the choice ID
+
 ## v0.1.1
 
 ### Bug Fixes

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: fragmentedpacket
 name: netbox_modules
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.1.1
+version: 0.1.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/module_utils/netbox_utils.py
+++ b/plugins/module_utils/netbox_utils.py
@@ -544,6 +544,8 @@ class NetboxModule(object):
             for choice in required_choices:
                 for key, value in choice.items():
                     if data.get(key):
+                        if isinstance(data[key], int):
+                            break
                         try:
                             data[key] = value[data[key].lower()]
                         except KeyError:

--- a/tests/integration/integration-tests.yml
+++ b/tests/integration/integration-tests.yml
@@ -3094,6 +3094,7 @@
           cluster: "Test Cluster"
           vcpus: 8
           memory: 8
+          status: 0
           virtual_machine_role: "Test VM Role"
           tags:
             - Schnozzberry
@@ -3106,12 +3107,14 @@
           - test_three is changed
           - test_three['diff']['after']['vcpus'] == 8
           - test_three['diff']['after']['memory'] == 8
+          - test_three['diff']['after']['status'] == 0
           - test_three['diff']['after']['role'] == 2
           - test_three['diff']['after']['tags'][0] == "Schnozzberry"
           - test_three['virtual_machine']['name'] == "Test VM One"
           - test_three['virtual_machine']['cluster'] == 1
           - test_three['virtual_machine']['vcpus'] == 8
           - test_three['virtual_machine']['memory'] == 8
+          - test_three['virtual_machine']['status'] == 0
           - test_three['virtual_machine']['role'] == 2
           - test_three['virtual_machine']['tags'][0] == "Schnozzberry"
           - test_three['msg'] == "virtual_machine Test VM One updated"
@@ -3133,6 +3136,8 @@
           - test_four['virtual_machine']['cluster'] == 1
           - test_four['virtual_machine']['vcpus'] == 8
           - test_four['virtual_machine']['memory'] == 8
+          - test_four['virtual_machine']['status'] == 0
+          - test_four['virtual_machine']['role'] == 2
           - test_four['virtual_machine']['tags'][0] == "Schnozzberry"
           - test_four['msg'] == "virtual_machine Test VM One deleted"
 


### PR DESCRIPTION
There are certain fields for modules that are tied to static choices and are dynamically determined via the string passed in and doing a lookup within netbox_utils.

This PR fixes #47 and allows integers to be passed in and doesn't attempt to dynamically determine what that integer value should be and just passes the integer to the API. This affects all fields that are within the [REQUIRED_ID_FIND](https://github.com/FragmentedPacket/netbox_modules/blob/devel/plugins/module_utils/netbox_utils.py#L348) within netbox_utils.

If the integer passed in is not a valid choice, the API should return an error and fail the module.