### PR TITLE
update lookup docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
 
     - name: "Python 3.6 - Netbox Latest - Ansible Devel"
       python: 3.6
-      env: PYTHON_VER=3.6 VERSION=v2.6.6
+      env: PYTHON_VER=3.6 VERSION=v2.6
       install:
         - cd ..
         # Setup netbox container for integration testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
 
     - name: "Python 3.6 - Netbox Latest - Ansible Devel"
       python: 3.6
-      env: PYTHON_VER=3.6 VERSION=v2.6
+      env: PYTHON_VER=3.6 VERSION=v2.6 SKIP_STARTUP_SCRIPTS=true
       install:
         - cd ..
         # Setup netbox container for integration testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
   include:
     - name: "Python 3.6 - Netbox 2.5 - Latest PyPi Ansible"
       python: 3.6
-      env: PYTHON_VER=3.6 VERSION=v2.5 SKIP_START_SCRIPTS=true
+      env: PYTHON_VER=3.6 VERSION=v2.5
       install:
         - cd ..
         # Setup netbox container for integration testing
@@ -31,7 +31,7 @@ matrix:
 
     - name: "Python 3.6 - Netbox Latest - Ansible Devel"
       python: 3.6
-      env: PYTHON_VER=3.6 VERSION=v2.6 SKIP_STARTUP_SCRIPTS=true
+      env: PYTHON_VER=3.6 VERSION=v2.6
       install:
         - cd ..
         # Setup netbox container for integration testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ env:
 
 matrix:
   include:
-    - name: "Python 3.6 - Netbox 2.5 - Ansible 2.9"
+    - name: "Python 3.6 - Netbox 2.5 - Latest PyPi Ansible"
       python: 3.6
-      env: PYTHON_VER=3.6 VERSION=v2.5 ANSIBLE_VER=2.9.0
+      env: PYTHON_VER=3.6 VERSION=v2.5 SKIP_START_SCRIPTS=true
       install:
         - cd ..
         # Setup netbox container for integration testing
@@ -27,7 +27,7 @@ matrix:
         - cd ..
         - pip install -U pip
         - pip install pytest==4.6.5 pytest-mock pytest-xdist jinja2 PyYAML black==19.10b0
-        - pip install pynetbox==4.0.6 cryptography codecov jmespath ansible==$ANSIBLE_VER
+        - pip install pynetbox==4.0.6 cryptography codecov jmespath ansible
 
     - name: "Python 3.6 - Netbox Latest - Ansible Devel"
       python: 3.6
@@ -35,7 +35,7 @@ matrix:
       install:
         - cd ..
         # Setup netbox container for integration testing
-        - git clone https://github.com/netbox-community/netbox-docker.git
+        - git clone https://github.com/FragmentedPacket/netbox-docker.git
         - cd netbox-docker
         - docker-compose pull
         - docker-compose up -d

--- a/plugins/lookup/netbox.py
+++ b/plugins/lookup/netbox.py
@@ -30,8 +30,7 @@ DOCUMENTATION = """
     description:
         - Queries Netbox via its API to return virtually any information
           capable of being held in Netbox.
-        - While secrets can be queried, the plugin doesn't yet support
-          decrypting them.
+        - If wanting to obtain the plaintext attribute of a secret, key_file must be provided.
     options:
         _terms:
             description:
@@ -49,6 +48,10 @@ DOCUMENTATION = """
             description:
                 - The API token created through Netbox
             required: True
+        key_file:
+            description:
+                - The location of the private key tied to user account.
+            required: False
     requirements:
         - pynetbox
 """
@@ -78,6 +81,12 @@ tasks:
                     api_endpoint='http://localhost/',
                     api_filter='role=management tag=Dell'),
                     token='<redacted>') }}"
+
+# Obtain a secret for R1-device
+tasks:
+  - name: "Obtain secrets for R1-Device"
+    debug:
+      msg: "{{ query('netbox', 'secrets', api_filter='device=R1-Device', api_endpoint='http://localhost/', token='<redacted>', key_file='~/.ssh/id_rsa') }}"
 """
 
 RETURN = """
@@ -149,9 +158,6 @@ def get_endpoint(netbox, term):
         "rirs": {"endpoint": netbox.ipam.rirs},
         "roles": {"endpoint": netbox.ipam.roles},
         "secret-roles": {"endpoint": netbox.secrets.secret_roles},
-        # Note: Currently unable to decrypt secrets as key wizardry needs to
-        # take place first but term will return unencrypted elements of secrets
-        # i.e. that they exist etc.
         "secrets": {"endpoint": netbox.secrets.secrets},
         "services": {"endpoint": netbox.ipam.services},
         "sites": {"endpoint": netbox.dcim.sites},


### PR DESCRIPTION
Update lookup plugin to remove documentation stating that secrets cannot be decrypted. Added docs on how to decrypt secrets using the `key_file` option

Fixes #30 